### PR TITLE
Remove howtotex

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 ## Templates
 
 - [LaTeX templates](http://www.latextemplates.com) - Collection of templates for papers, posters, resumés, theses, books, presentations, … for LaTeX.
-- [HowtoTeX: templates](http://www.howtotex.com/category/templates/) - Different templates for LaTeX under a CC-NC-SA license.
 - [Ultimate Beamer Theme List](https://github.com/martinbjeldbak/ultimate-beamer-theme-list) - Links to various beamer themes along with PDF previews.
 
 ## Symbols
@@ -195,9 +194,7 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 - [TeXample](http://www.texample.net) - Blog about LaTex, with a big collection of TikZ figures.
 - [LaTeX cookbook](http://latex-cookbook.net) - Sibling of TeXample, contains quite a bit of example code.
 - [Visual FAQ](http://mirrors.ctan.org/info/visualFAQ/visualFAQ.pdf) - Typesetting issues and a link to appropriate TeX FAQ answers.
-- [12 Great resources for getting started with LaTeX](http://www.howtotex.com/general/12-great-resources-for-getting-started-with-latex/) - Nice overview of useful resources for beginners.
 - [MartinThoma's LaTeX example](https://github.com/MartinThoma/LaTeX-examples/) - GitHub repository containing example LaTeX documents.
-- [HowtoTeX LaTeX](http://latex.howtotex.com) - Start page with useful resources for LaTeX users.
 - [MacTeX Wiki: TeX Extras](http://mactex-wiki.tug.org/wiki/index.php/TeX_Extras) - Overview of useful tools for LaTeX. Many of them are specific for Mac, but quite a bit are useful for other platforms as well.
 - [LaTeX community](http://latex-community.org/index.php) - Forum and blog about LaTeX.
 - German: [Neue TeX FAQ](http://texfragen.de/) - A modern and updated LaTeX FAQ in German.


### PR DESCRIPTION
Howtotex is dead:

![grafik](https://user-images.githubusercontent.com/1366654/31925978-34b72b38-b88c-11e7-9856-9071045d650a.png)

The last template updates are from 2012 (https://web.archive.org/web/20170121025559/http://www.howtotex.com:80/category/templates/):

![grafik](https://user-images.githubusercontent.com/1366654/31925973-2e693fa0-b88c-11e7-8919-68c8479196c5.png)

12 Great resources from 2013 (https://web.archive.org/web/20170104065734/http://www.howtotex.com/general/12-great-resources-for-getting-started-with-latex/):

![grafik](https://user-images.githubusercontent.com/1366654/31926011-7693cb7e-b88c-11e7-841d-21c8a8240bb1.png)

So, I just remove it. Sure, the content should be migrated somehow to GitHub to ensure durability of the content.
