### PR TITLE
Fix various formatting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ This is a curated list of awesome stuff for the (La)TeX typesetting system.
 ## Distributions
 
 - [MacTeX](https://tug.org/mactex/) - Most common LaTeX distribution for Mac OS X, basically TeXLive with some Mac-specific tools added. ![Mac][mac]
-- [TeX Live](http://www.tug.org/texlive/) - Most common LaTeX distribution for Unices and Linux, but also works on Windows. ![Linux][linux] ![Windows][windows]
-- [MikTeX](http://miktex.org) - Most common LaTeX distribution for Windows (only). ![Windows][windows]
+- [TeX Live](https://www.tug.org/texlive/) - Most common LaTeX distribution for Unix-like operating systems, including GNU/Linux. Also works on Windows. ![Linux][linux] ![Windows][windows]
+- [MikTeX](https://miktex.org) - Most common LaTeX distribution for Windows (only). ![Windows][windows]
 
 ## Engines
 
-- [pdfTeX](http://www.tug.org/applications/pdftex/) - TeX compiler that produces PDF files immediately instead of DVI files (nowadays, this is the standard compiler for many users). ![foss][foss]
+- [pdfTeX](https://www.tug.org/applications/pdftex/) - TeX compiler that produces PDF files immediately instead of DVI files (nowadays, this is the standard compiler for many users). ![foss][foss]
 - [XeTeX](http://xetex.sourceforge.net) - TeX compiler that provides better unicode and font support than TeX/pdfTeX (i.e. you can use the  fonts of your operating system instead of only TeX fonts). ![foss][foss]
 - [LuaTeX](http://www.luatex.org) - (La)TeX compiler that supports Lua code for scripting and has improved unicode and font support than standard TeX/pdfTeX. ![foss][foss]
 
@@ -60,22 +60,21 @@ This is a curated list of awesome stuff for the (La)TeX typesetting system.
 
 Because editing LaTeX code with notepad is not awesome.
 There are many editors out there, below are the most awesome editors.
-A complete list of latex editors is collected at [tex.stackexchange.com](http://tex.stackexchange.com/) as [big list of LaTeX Editors/IDEs](http://tex.stackexchange.com/q/339/9075).
-
+A complete list of LaTeX editors is collected at [tex.stackexchange.com](https://tex.stackexchange.com/) as [big list of LaTeX Editors/IDEs](https://tex.stackexchange.com/q/339/9075).
 
 - [List of popular LaTeX editors](https://tex.stackexchange.com/questions/339/latex-editors-ides) - Community-maintained list of popular LaTeX editors including a screenshot and a short description.
 
 ### LaTeX-focussed
 
-Some of the most awesome editor for LaTeX do just that: edit LaTeX
+Some of the most awesome editor for LaTeX do just that: edit LaTeX.
 
-- [Kile](http://kile.sourceforge.net) - Just a great LaTeX editor originally from the Linux/KDE community, but runs just fine on Windows and OS X as well. ![foss][foss]
+- [Kile](https://kile.sourceforge.io) - A great LaTeX editor originally from the Linux/KDE community. It runs fine on Windows and OS X as well. ![foss][foss]
 - [TeXMaker](http://www.xm1math.net/texmaker/) - Pretty good alternative to Kile.
-- [TeXStudio](http://www.texstudio.org) - Cross-platform LaTeX editor that stems from TeXMaker.
+- [TeXStudio](https://www.texstudio.org) - Cross-platform LaTeX editor that stems from TeXMaker.
 - [WinEdt](http://www.winedt.com) - The LaTeX editor many people swear by. Only for ![Windows][windows].
 - [TeXnicCenter](http://www.texniccenter.org) - A quite old but free and decent editor for LaTeX. ![Windows][windows]
 - [LyX](https://www.lyx.org) - Cross-platform WYSIWYM editor that uses LaTeX behind the scenes to render documents. ![foss][foss]
-- [TeXshop](http://pages.uoregon.edu/koch/texshop/) - No-nonsense editor for LaTeX documents which is included in MacTeX. ![Mac][mac]
+- [TeXShop](http://pages.uoregon.edu/koch/texshop/) - No-nonsense editor for LaTeX documents which is included in MacTeX. ![Mac][mac]
 - [TeXWorks](https://www.tug.org/texworks/) - No-nonsense editor for LaTeX code, modeled after TeXShop, but this one is cross-platform. ![foss][foss]
 - [BakomaTex](http://www.bakoma-tex.com) - Commercial LaTeX editor that allows to edit your document both using its source code and WYSIWYG.
 - [Inlage](http://www.inlage.com/home) - Commercial LaTeX editor with handwritten formula recognition, Excel importing and more nifty features. ![Windows][windows]
@@ -88,14 +87,13 @@ These editors are no one-trick ponies: sure, they edit LaTeX, but they can do a 
 - [Atom](https://atom.io) [![Atom][awesome]](https://github.com/mehcode/awesome-atom) ![foss][foss]
 	- [LaTeXTools](https://atom.io/packages/latextools) - An Atom port of the Sublime Text package of the same name. ![foss][foss]
 
-- [Sublime Text](http://www.sublimetext.com) [![Sublime Text][awesome]](https://github.com/dreikanter/sublime-bookmarks)
+- [Sublime Text](https://www.sublimetext.com) [![Sublime Text][awesome]](https://github.com/dreikanter/sublime-bookmarks)
 	- [LaTeXing](http://www.latexing.com) - Commercial plug-in to edit LaTeX.
 	- [LaTeXTools](https://github.com/SublimeText/LaTeXTools) - Free LaTeX plugin for Sublime Text. ![foss][foss]
 
 - [Emacs](https://www.gnu.org/software/emacs/)  [![Emacs][awesome]](https://github.com/emacs-tw/awesome-emacs) ![foss][foss]
 	- [AucTeX](https://www.gnu.org/software/auctex/) - Emacs plugin for LaTeX that also shows a preview of equations and figures. ![foss][foss]	
 	- [RefTeX](https://www.gnu.org/software/auctex/reftex) - Emacs plugin for LaTeX that adds support for labels, references, and citations. ![foss][foss]
-
 
 - [Vim](http://www.vim.org) [![Vim][awesome]](https://github.com/mhinz/vim-galore) ![foss][foss]
 	- [Vim-LaTeX](http://vim-latex.sourceforge.net) ![foss][foss]
@@ -114,7 +112,7 @@ Online editors that allow you to edit documents collaboratively.
 - [ShareLaTeX](https://www.sharelatex.com) - Has pretty great LaTeX documentation and simple version control.
 - [Overleaf](https://www.overleaf.com) - Online editor, also with a WYSIWYM editor and git support.
 - [Papeeria](https://papeeria.com) - Online editor with built-in git support.
-- [JaxEdit](http://jaxedit.com/page/jaxedit.html) - Online LaTeX editor with Live Preview and nice presentation mode.
+- [JaxEdit](https://zohooo.github.io/jaxedit/) - Online LaTeX editor with Live Preview and nice presentation mode.
 
 ## Bibliography tools
 
@@ -138,10 +136,10 @@ Compiling LaTeX documents can be tedious, build tools help you to manage the com
 ## Misc. Tools
 
 - [CaTeX](https://github.com/Alexis-benoist/CaTeX) - Concatenates LaTeX documents with attention for properly merging the preamble.
-- [Pandoc](http://pandoc.org) - This program converts almost any document format (LaTeX, DOC, markdown, ...) to almost any other format. A great tool to aid workflows where multiple formats are used. ![foss][foss]
+- [Pandoc](https://pandoc.org) - This program converts almost any document format (LaTeX, DOC, markdown, ...) to almost any other format. A great tool to aid workflows where multiple formats are used. ![foss][foss]
 - [Codecogs Eqn Editor](https://www.codecogs.com/latex/eqneditor.php) - Online LaTeX equation editor that allows you to produce figures containing an equation.
-- [LaTeXiT](http://www.chachatelier.fr/latexit/) - LaTeXit is an equation editor that makes it easy to drag-and-drop rendered equations (as PDF, PNG, ...) into your non-LaTeX documents on the Mac. ![Mac][mac]
-- [KLaTeXFormula](http://klatexformula.sourceforge.net) - Cross-platform alternative for LaTeXit. ![foss][foss]
+- [LaTeXiT](https://www.chachatelier.fr/latexit/) - LaTeXit is an equation editor that makes it easy to drag-and-drop rendered equations (as PDF, PNG, ...) into your non-LaTeX documents on the Mac. ![Mac][mac]
+- [KLaTeXFormula](https://klatexformula.sourceforge.io) - Cross-platform alternative for LaTeXit. ![foss][foss]
 - [EqualX](http://equalx.sourceforge.net) - Graphical LaTeX formula editor. ![Windows][windows] ![Linux][linux] ![foss][foss]
 - [ChkTeX](http://baruch.ev-en.org/proj/chktex/) - Linter / code checker for LaTeX documents. ![foss][foss]
 
@@ -150,19 +148,19 @@ Compiling LaTeX documents can be tedious, build tools help you to manage the com
 - [TikzEdt](http://www.tikzedt.org) (also:  [GitHub repo](https://github.com/hchapman/tikzedt)) - WYSIWYG and text-based editor for TikZ pictures. ![foss][foss]
 - [TikZ-Editor](https://github.com/fredokun/TikZ-Editor) - Live-previewing editor for TikZ figures. ![Mac][Mac] ![Linux][Linux] ![foss][foss]
 - [IPE](http://ipe.otfried.org) - Drawing tool that integrates well with LaTeX commands and documents. ![foss][foss]
-- [GeoGebra](http://www.geogebra.org/cms/) - Cross-platform geometry tool with output to TikZ. ![foss][foss]
+- [GeoGebra](https://www.geogebra.org/cms/) - Cross-platform geometry tool with output to TikZ. ![foss][foss]
 - [Dia](https://wiki.gnome.org/Apps/Dia) - Cross-platform diagramming tool that can export to PSTricks and MetaPost code. ![foss][foss]
 
 ## Packages
 
-- [CTAN](http://ctan.org) - The Comprehensive TeX Archive Network is the place to look for useful packages and documentation.
+- [CTAN](https://www.ctan.org) - The Comprehensive TeX Archive Network is the place to look for useful packages and documentation.
 
 ### Tables
 
 - [Excel2LaTeX](https://www.ctan.org/pkg/excel2latex?lang=en) - Excel (2010 and older) macros to produce LaTeX `tabular` code. ![Windows][windows] ![Mac][mac]
-- [csv2latex](http://www.freecode.com/projects/csv2latex) - Converts CSV files from your favorite programs to LaTeX `tabular`s. ![Linux][linux] ![Mac][mac]
-- [Tables Generator](http://www.tablesgenerator.com) - This website provides a graphical interface to input your table and produces properly-formatted code for LaTeX, Markdown, HTML, ...
-- [pgfplotstable](https://www.ctan.org/pkg/pgfplotstable?lang=en) - This package dis­plays nu­mer­i­cal ta­bles rounded to de­sired pre­ci­sion in var­i­ous dis­play for­mats. It can even read CSV files to include directly in your LaTeX document.
+- [csv2latex](http://freshmeat.sourceforge.net/projects/csv2latex) - Converts CSV files from your favorite programs to LaTeX `tabular`s. ![Linux][linux] ![Mac][mac]
+- [Tables Generator](https://www.tablesgenerator.com) - This website provides a graphical interface to input your table and produces properly-formatted code for LaTeX, Markdown, HTML, etc.
+- [pgfplotstable](https://www.ctan.org/pkg/pgfplotstable?lang=en) - This package displays numerical tables rounded to desired precision in various display formats. It can even read CSV files to include directly in your LaTeX document.
 
 ### Graphics
 
@@ -175,21 +173,21 @@ PSTricks is a great library to draw figures for inclusion in PostScript/DVI file
 TikZ is an awesome package with many plugins that allow you to create figures from within your LaTeX documents.
 Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 
-- [TeXample](http://www.texample.net) - Blog about LaTex, with a big collection of TikZ figures.
-- [LaTeX en SI](http://sciences-indus-cpge.papanicola.info/-LaTeX-en-SI-) - Useful website with some custom packages to draw special plots (Bode, Nyquist, electrical schematics, block schematics, ...) using TikZ. Note that everything is in French.
+- [TeXample](http://www.texample.net) - Blog about LaTeX, with a big collection of TikZ figures.
+- [LaTeX en SI](https://sciences-indus-cpge.papanicola.info/-LaTeX-en-SI-) - Useful website with some custom packages to draw special plots (Bode, Nyquist, electrical schematics, block schematics, ...) using TikZ. Note that everything is in French.
 - [tkz](http://altermundus.com/pages/tkz/index.html) - A collection of TikZ-based packages to make plots and graphs.
-- [pgfplots](http://pgfplots.sourceforge.net) - A truely awesome plotting library on top of and in the style of TikZ/pgf. This library can load in CSV data files, perform some calculations and create beautiful plots.
-- [A very minimal introduction to TikZ (PDF)](http://bit.ly/gNfVn9) - A short introductory document to the world of TikZ, written by Jacques Crémer.
+- [pgfplots](http://pgfplots.sourceforge.net) - A truly awesome plotting library on top of and in the style of TikZ/pgf. This library can load in CSV data files, perform some calculations and create beautiful plots.
+- [A very minimal introduction to TikZ (PDF)](https://cremeronline.com/LaTeX/minimaltikz.pdf) - A short introductory document to the world of TikZ, written by Jacques Crémer.
 - [PetarV-/TikZ](https://github.com/PetarV-/TikZ) - A collection of publication-ready PGF/TikZ figures by Petar Veličković.
 
 ## Templates
 
-- [LaTeX templates](http://www.latextemplates.com) - Collection of templates for papers, posters, resumés, theses, books, presentations, … for LaTeX.
+- [LaTeX templates](https://www.latextemplates.com) - Collection of templates for papers, posters, resumés, theses, books, presentations, … for LaTeX.
 - [Ultimate Beamer Theme List](https://github.com/martinbjeldbak/ultimate-beamer-theme-list) - Links to various beamer themes along with PDF previews.
 
 ## Symbols
 
-- [Comprehensive LaTeX symbol list](http://www.ctan.org/tex-archive/info/symbols/comprehensive/) - A very extensive list of symbols for LaTeX. Available in [A4](http://mirrors.ctan.org/info/symbols/comprehensive/symbols-a4.pdf) and [letter](http://mirrors.ctan.org/info/symbols/comprehensive/symbols-letter.pdf) sizes.
+- [Comprehensive LaTeX symbol list](https://www.ctan.org/tex-archive/info/symbols/comprehensive/) - A very extensive list of symbols for LaTeX. Available in [A4](http://mirrors.ctan.org/info/symbols/comprehensive/symbols-a4.pdf) and [letter](http://mirrors.ctan.org/info/symbols/comprehensive/symbols-letter.pdf) sizes.
 - [Detexify](http://detexify.kirelabs.org/classify.html) - You draw the symbol and this site/app will tell you the LaTeX command.
 
 ## Resources
@@ -198,26 +196,25 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 - [TeXDoc](http://texdoc.net) - Online interface to the `texdoc` utility to browse LaTeX packages and documentation.
 - [Dickimaw Books: LaTeX resources](http://www.dickimaw-books.com/latexresources.html) - Great overview of resources useful for LaTeX.
 - [Showcase of beautiful typography done in TeX & friends](https://tex.stackexchange.com/q/1319/9075) - Community-maintained and ranked show cases what is possible with LaTeX.
-- [TUG: TeX showcase](http://www.tug.org/texshowcase/) - Website from the TUG that shows some examples of what LaTeX can do.
-- [TeXample](http://www.texample.net) - Blog about LaTex, with a big collection of TikZ figures.
+- [TUG: TeX showcase](https://www.tug.org/texshowcase/) - Website from the TUG that shows some examples of what LaTeX can do.
 - [LaTeX cookbook](http://latex-cookbook.net) - Sibling of TeXample, contains quite a bit of example code.
 - [Visual FAQ](http://mirrors.ctan.org/info/visualFAQ/visualFAQ.pdf) - Typesetting issues and a link to appropriate TeX FAQ answers.
 - [MartinThoma's LaTeX example](https://github.com/MartinThoma/LaTeX-examples/) - GitHub repository containing example LaTeX documents.
 - [MacTeX Wiki: TeX Extras](http://mactex-wiki.tug.org/wiki/index.php/TeX_Extras) - Overview of useful tools for LaTeX. Many of them are specific for Mac, but quite a bit are useful for other platforms as well.
-- [LaTeX community](http://latex-community.org/index.php) - Forum and blog about LaTeX.
-- German: [Neue TeX FAQ](http://texfragen.de/) - A modern and updated LaTeX FAQ in German.
+- [LaTeX community](http://latex.org/index.php) - Forum and blog about LaTeX.
+- German: [Neue TeX FAQ](https://texfragen.de) - A modern and updated LaTeX FAQ in German.
 
 ## Tutorials
 
 - [The (Not So) Short Introduction to LaTeX2e](http://mirrors.ctan.org/info/lshort/english/lshort.pdf) - A very comprehensive introduction to LaTeX.
-- [Begin LaTeX in minutes](https://github.com/LewisVo/Begin-Latex-in-minutes) - Brief Intro to LaTeX for beginners that helps you use LaTeX with ease
+- [Begin LaTeX in minutes](https://github.com/LewisVo/Begin-Latex-in-minutes) - A brief intro to LaTeX for beginners that helps you use LaTeX with ease.
 - [Getting to Grips with LaTeX](https://www.andy-roberts.net/writing/latex) - A complete guide going through the majority of things you need to know about LaTeX.
 
 ## Books
 
-- [WikiBooks: LaTeX](https://en.wikibooks.org/wiki/LaTeX) - The LaTeX wikibook. Not really a paper book, but it is equally extensive.
-- [The LaTeX Companion, F. Mittelbach (2004)](http://www.informit.com/store/latex-companion-9780201362992)
-- [LaTeX Graphics Companion, M. Goossens (2007)](http://www.informit.com/store/latex-graphics-companion-9780321508928)
+- [Wikibooks: LaTeX](https://en.wikibooks.org/wiki/LaTeX) - The LaTeX wikibook. Not really a paper book, but it is equally extensive.
+- [The LaTeX Companion, F. Mittelbach (2004)](https://www.informit.com/store/latex-companion-9780201362992)
+- [LaTeX Graphics Companion, M. Goossens (2007)](https://www.informit.com/store/latex-graphics-companion-9780321508928)
 
 ## Blogs
 
@@ -226,8 +223,8 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 ## Social media
 
 - [LinkedIn: TeX/LaTeX User Group](https://www.linkedin.com/groups/1600297)
-- [Twitter: @TeXtip](https://twitter.com/TeXtip) - Tips related to (La)TeX by [John D. Cook](http://www.johndcook.com/).
-- [TeX.StackExchange](http://tex.stackexchange.com) - StackExchange TeX section.
+- [Twitter: @TeXtip](https://twitter.com/TeXtip) - Tips related to (La)TeX by [John D. Cook](https://www.johndcook.com/).
+- [TeX.StackExchange](https://tex.stackexchange.com) - StackExchange TeX section.
 
 ---------------------------------------------------------------------------
 
@@ -243,10 +240,10 @@ The icons indicating Mac, Linux and Windows compatibility show when a program is
 
 |       Logo          | Description                                            |
 |:-------------------:|:-------------------------------------------------------|
-| ![Mac][mac]         | [Mac OS X](http://www.apple.com/osx/)                  |
-| ![Linux][linux]     | [GNU/Linux](http://www.linux.org)                      |
+| ![Mac][mac]         | [Mac OS X](https://www.apple.com/osx/)                 |
+| ![Linux][linux]     | [GNU/Linux](https://www.gnu.org)                       |
 | ![Windows][windows] | [Microsoft Windows](https://www.microsoft.com/windows) |
-| ![FOSS][FOSS]      | [Free Open-Source Software](https://opensource.org)     |
+| ![FOSS][FOSS]       | [Free Open-Source Software](https://opensource.org)    |
 
 ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request:

- Changes `http://` to `https://` for websites that use a secure connection. This prevents the user from requesting an insecure URL when a secure one exists.
- Fixes a few of the older links redirecting to other websites.
- Fixes [GNU/Linux](https://www.gnu.org/) not linking to the proper website.
- Fixes some typos such as `latex` not being `LaTeX`.
- Removes weird formatting from the `pgfplotstable` line.
- Removes a duplicate entry `TeXample`.