### PR TITLE
Add minted, microtype and two more showcases (in separate section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,34 +5,37 @@ This is a curated list of awesome stuff for the (La)TeX typesetting system.
 
 ## Contents
 
-<!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
+<!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
-- [Awesome LaTeX](#awesome-latex)
-	- [Contents](#contents)
-	- [Distributions](#distributions)
-	- [Engines](#engines)
-		- [LaTeX formulas on the web](#latex-formulas-on-the-web)
-	- [Editors](#editors)
-		- [LaTeX-focussed](#latex-focussed)
-		- [General purpose text editors](#general-purpose-text-editors)
-		- [Online editors](#online-editors)
-	- [Bibliography tools](#bibliography-tools)
-	- [Misc. Tools](#misc-tools)
-	- [LaTeX-compatible GUI tools](#latex-compatible-gui-tools)
-	- [Packages](#packages)
-		- [Tables](#tables)
-		- [Graphics](#graphics)
-			- [PSTricks](#pstricks)
-			- [TikZ](#tikz)
-	- [Templates](#templates)
-	- [Symbols](#symbols)
-	- [Resources](#resources)
-	- [Tutorials](#tutorials)
-	- [Books](#books)
-	- [Blogs](#blogs)
-	- [Social media](#social-media)
+- [Contents](#contents)
+- [Distributions](#distributions)
+- [Engines](#engines)
+	- [LaTeX formulas on the web](#latex-formulas-on-the-web)
+- [Editors](#editors)
+	- [LaTeX-focused](#latex-focused)
+	- [General purpose text editors](#general-purpose-text-editors)
+	- [Online editors](#online-editors)
+- [Bibliography tools](#bibliography-tools)
+- [Build Tools](#build-tools)
+- [Misc. Tools](#misc-tools)
+- [LaTeX-compatible GUI tools](#latex-compatible-gui-tools)
+- [Packages](#packages)
+	- [Tables](#tables)
+	- [Graphics](#graphics)
+		- [PSTricks](#pstricks)
+		- [TikZ](#tikz)
+	- [Source Code](#source-code)
+	- [Typography](#typography)
+- [Templates](#templates)
+- [Symbols](#symbols)
+- [Resources](#resources)
+- [Showcases](#showcases)
+- [Tutorials](#tutorials)
+- [Books](#books)
+- [Blogs](#blogs)
+- [Social media](#social-media)
 - [Meta Awesome-LaTeX](#meta-awesome-latex)
-	- [Legend](#legend)
+- [Legend](#legend)
 
 <!-- /TOC -->
 
@@ -92,7 +95,7 @@ These editors are no one-trick ponies: sure, they edit LaTeX, but they can do a 
 	- [LaTeXTools](https://github.com/SublimeText/LaTeXTools) - Free LaTeX plugin for Sublime Text. ![foss][foss]
 
 - [Emacs](https://www.gnu.org/software/emacs/)  [![Emacs][awesome]](https://github.com/emacs-tw/awesome-emacs) ![foss][foss]
-	- [AucTeX](https://www.gnu.org/software/auctex/) - Emacs plugin for LaTeX that also shows a preview of equations and figures. ![foss][foss]	
+	- [AucTeX](https://www.gnu.org/software/auctex/) - Emacs plugin for LaTeX that also shows a preview of equations and figures. ![foss][foss]
 	- [RefTeX](https://www.gnu.org/software/auctex/reftex) - Emacs plugin for LaTeX that adds support for labels, references, and citations. ![foss][foss]
 
 - [Vim](http://www.vim.org) [![Vim][awesome]](https://github.com/mhinz/vim-galore) ![foss][foss]
@@ -184,11 +187,11 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 
 ### Source Code
 
-- [minted](https://www.ctan.org/pkg/minted) - The minted package uses [pygments](http://pygments.org/) to generate the listings. In that way, LaTeX is able to format more than 300 languages and other text formats.
+- [minted](https://www.ctan.org/pkg/minted) - The minted package uses [pygments](http://pygments.org/) to generate the listings. In this way, LaTeX is able to format more than 300 programming and markup languages and other text formats.
 
 ### Typography
 
-- [microtype](https://ctan.org/pkg/microtype) - This enables margin kerning and font expansion. This just makes a document look much better.
+- [microtype](https://ctan.org/pkg/microtype) - This package improves the appearance of your documents by enabling margin kerning and font expansion.
 
 ## Templates
 
@@ -205,7 +208,6 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 - [TUG](https://www.tug.org) - The TeX User Group is a way to get in touch with other (La)TeX users.
 - [TeXDoc](http://texdoc.net) - Online interface to the `texdoc` utility to browse LaTeX packages and documentation.
 - [Dickimaw Books: LaTeX resources](http://www.dickimaw-books.com/latexresources.html) - Great overview of resources useful for LaTeX.
-- [TUG: TeX showcase](https://www.tug.org/texshowcase/) - Website from the TUG that shows some examples of what LaTeX can do.
 - [LaTeX cookbook](http://latex-cookbook.net) - Sibling of TeXample, contains quite a bit of example code.
 - [Visual FAQ](http://mirrors.ctan.org/info/visualFAQ/visualFAQ.pdf) - Typesetting issues and a link to appropriate TeX FAQ answers.
 - [MartinThoma's LaTeX example](https://github.com/MartinThoma/LaTeX-examples/) - GitHub repository containing example LaTeX documents.
@@ -216,9 +218,10 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 
 ## Showcases
 
-- [Showcase of beautiful typography done in TeX & friends](https://tex.stackexchange.com/questions/1319/showcase-of-beautiful-typography-done-in-tex-friends) - A collection of showcases demonstrating the power of LaTeX.
-- [Showcase of beautiful invitations in TeX](https://tex.stackexchange.com/q/281415/9075) - A collection of invitations typeset using LaTeX.
-- [Showcase of "programming your document" paradigm](https://tex.stackexchange.com/q/219774/9075) - A collection of LaTeX documents which contains code to produce the text.
+- [Showcase of beautiful typography done in TeX & friends](https://tex.stackexchange.com/questions/1319/showcase-of-beautiful-typography-done-in-tex-friends) - A set of examples demonstrating the power of LaTeX.
+- [Showcase of beautiful invitations in TeX](https://tex.stackexchange.com/q/281415/9075) - A showcase of invitations typeset using LaTeX.
+- [Showcase of "programming your document" paradigm](https://tex.stackexchange.com/q/219774/9075) - A collection of LaTeX documents demonstrating how LaTeX can be used like a programming language.
+- [TUG: TeX showcase](https://www.tug.org/texshowcase/) - Website from the TUG that shows some examples of what LaTeX can do.
 
 ## Tutorials
 
@@ -246,7 +249,7 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 
 <!-- Icons -->
 
-# Meta Awesome-LaTeX
+## Meta Awesome-LaTeX
 
 If you want to contribute, please do read our [CONTRIBUTING](CONTRIBUTING.md) guidelines.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A complete list of LaTeX editors is collected at [tex.stackexchange.com](https:/
 
 - [List of popular LaTeX editors](https://tex.stackexchange.com/questions/339/latex-editors-ides) - Community-maintained list of popular LaTeX editors including a screenshot and a short description.
 
-### LaTeX-focussed
+### LaTeX-focused
 
 Some of the most awesome editor for LaTeX do just that: edit LaTeX.
 
@@ -182,6 +182,14 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 - [A very minimal introduction to TikZ (PDF)](https://cremeronline.com/LaTeX/minimaltikz.pdf) - A short introductory document to the world of TikZ, written by Jacques Crémer.
 - [PetarV-/TikZ](https://github.com/PetarV-/TikZ) - A collection of publication-ready PGF/TikZ figures by Petar Veličković.
 
+### Source Code
+
+- [minted](https://www.ctan.org/pkg/minted) - The minted package uses [pygments](http://pygments.org/) to generate the listings. In that way, LaTeX is able to format more than 300 languages and other text formats.
+
+### Typography
+
+- [microtype](https://ctan.org/pkg/microtype) - This enables margin kerning and font expansion. This just makes a document look much better.
+
 ## Templates
 
 - [LaTeX templates](https://www.latextemplates.com) - Collection of templates for papers, posters, resumés, theses, books, presentations, … for LaTeX.
@@ -197,7 +205,6 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 - [TUG](https://www.tug.org) - The TeX User Group is a way to get in touch with other (La)TeX users.
 - [TeXDoc](http://texdoc.net) - Online interface to the `texdoc` utility to browse LaTeX packages and documentation.
 - [Dickimaw Books: LaTeX resources](http://www.dickimaw-books.com/latexresources.html) - Great overview of resources useful for LaTeX.
-- [Showcase of beautiful typography done in TeX & friends](https://tex.stackexchange.com/q/1319/9075) - Community-maintained and ranked show cases what is possible with LaTeX.
 - [TUG: TeX showcase](https://www.tug.org/texshowcase/) - Website from the TUG that shows some examples of what LaTeX can do.
 - [LaTeX cookbook](http://latex-cookbook.net) - Sibling of TeXample, contains quite a bit of example code.
 - [Visual FAQ](http://mirrors.ctan.org/info/visualFAQ/visualFAQ.pdf) - Typesetting issues and a link to appropriate TeX FAQ answers.
@@ -206,6 +213,12 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 - [LaTeX community](http://latex.org/index.php) - Forum and blog about LaTeX.
 - German: [Neue TeX FAQ](https://texfragen.de) - A modern and updated LaTeX FAQ in German.
 - [BibTeX Style Examples](http://www.cs.stir.ac.uk/~kjt/software/latex/showbst.html) - Example output of common BibTeX styles (BST files).
+
+## Showcases
+
+- [Showcase of beautiful typography done in TeX & friends](https://tex.stackexchange.com/questions/1319/showcase-of-beautiful-typography-done-in-tex-friends) - A collection of showcases demonstrating the power of LaTeX.
+- [Showcase of beautiful invitations in TeX](https://tex.stackexchange.com/q/281415/9075) - A collection of invitations typeset using LaTeX.
+- [Showcase of "programming your document" paradigm](https://tex.stackexchange.com/q/219774/9075) - A collection of LaTeX documents which contains code to produce the text.
 
 ## Tutorials
 


### PR DESCRIPTION
This adds a separate Section "Showcases"

I did not know where the `TOC` is generated with - I always use [markdown-toc](https://www.npmjs.com/package/markdown-toc):

    <!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->

Can this be changed to

    <!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->

To be in line with the TOC of other awesome lists. Then, I would also add second-level heading to "Meta Awesome-LaTeX"