### PR TITLE
Added texblog.org to list of blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 ## Blogs
 
 - [TeXblog](http://texblog.net) - Blog about LaTeX and everything related.
+- [texblog.org](https://texblog.org) - Blog on LaTeX and related topics (tutorials, packages, code snippets, etc.).
 - [TeX Talk](http://tex-talk.net) - Blog for the TeX Stack Exchange site with news and interviews.
 
 ## Social media


### PR DESCRIPTION
I added https://texblog.org to the list of active LaTeX blogs.