### PR TITLE
Check links each Friday

### DIFF
--- a/.github/workflows/awesome-bot.yml
+++ b/.github/workflows/awesome-bot.yml
@@ -2,9 +2,9 @@ name: awesome-bot
 
 on:
   push:
-    branches: [ '*' ]
   pull_request:
-    branches: [ '*' ]
+  schedule:
+    - cron: 5 4 * * 5
 
 jobs:
   build:


### PR DESCRIPTION
Links may disappear over time - and not only when a PR is submitted. This PR adds a weekly check for the links.

Triggered by https://github.com/egeerardyn/awesome-LaTeX/actions/runs/4594124506/jobs/8112774763:

```
Issues :-(
> Links 
  1. [L228]  https://altermundus.com/pages/tkz/index.html Failed to open TCP connection to altermundus.com:443 (getaddrinfo: Name or service not known) 
```

Also streamlines syntax (as default, all branches and PRs are checked)