### PR TITLE
Add VS Code Devcontainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ These editors are no one-trick ponies: sure, they edit LaTeX, but they can do a 
 - [VS Code](https://code.visualstudio.com/) [![VS Code][awesome]](https://github.com/viatsko/awesome-vscode) ![foss]
   - [LaTeX Workshop](https://github.com/James-Yu/LaTeX-Workshop) - LaTeX extension for Visual Studio Code ![foss]
   - [LTeX](https://marketplace.visualstudio.com/items?itemName=valentjn.vscode-ltex) - LanguageTool grammar/spell checking ![foss]
+  - [a-nau/latex-devcontainer](https://github.com/a-nau/latex-devcontainer) - Devcontainer setup for easy LaTeX usage without local installation ![foss]
+
 
 ### Online editors
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ These editors are no one-trick ponies: sure, they edit LaTeX, but they can do a 
   - [LTeX](https://marketplace.visualstudio.com/items?itemName=valentjn.vscode-ltex) - LanguageTool grammar/spell checking ![foss]
   - [a-nau/latex-devcontainer](https://github.com/a-nau/latex-devcontainer) - Devcontainer setup for easy LaTeX usage without local installation ![foss]
 
-
 ### Online editors
 
 Online editors that allow you to edit documents collaboratively.


### PR DESCRIPTION
Thanks for putting this together!

I created a [small project](https://github.com/a-nau/latex-devcontainer) to make using LaTeX with Visual Studio Code hassle-free by creating a ready-to-use Devcontainer with

- Common LaTeX Plugins
- Gitlab and Github CI
- One-click arXiv export
- One-click URL check

I think this could be very helpful for people who want or need to work with LaTeX without a local installation. I didn't know whether the project would be a better match for "VS Code" or for "Build Tools", since it essentially simplifies building LaTeX using VS Code.

If you have any feedback on the project, I'd be very happy to hear it!

Best
Alex