### PR TITLE
Add TeX Hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 - [TeXblog](https://texblog.net) - Blog about LaTeX and everything related.
 - [texblog.org](https://texblog.org) - Blog on LaTeX and related topics (tutorials, packages, code snippets, etc.).
 - [TeX Talk](https://tex-talk.net) - Blog for the TeX Stack Exchange site with news and interviews.
+- [TeX Hour](https://texhour.github.io/) - A weekly video meeting
 
 ## Social media
 


### PR DESCRIPTION
I found https://texhour.github.io/. And I really liked it: Discussions about TeX and friends. For instance "[Digital Typography: from DESQview to Wayland](https://texhour.github.io/2023/02/23/digit-typo-desqview-wayland/)"

Did not want to open a new category - therefore, I put it into "Blogs"