### PR TITLE
Update Texpad to Texifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Some of the most awesome editor for LaTeX do just that: edit LaTeX.
 - [TeXShop](https://pages.uoregon.edu/koch/texshop/) - No-nonsense editor for LaTeX documents which is included in MacTeX. ![mac]
 - [TeXWorks](https://www.tug.org/texworks/) - No-nonsense editor for LaTeX code, modeled after TeXShop, but this one is cross-platform. ![foss]
 - [BakomaTex](https://www.bakoma-tex.com) - Commercial LaTeX editor that allows to edit your document both using its source code and WYSIWYG.
-- [Texpad](https://www.texpad.com) - Commercial LaTeX editor for macOS and iOS, with excellent features (document overview, synchronised PDF display, autocompletion, sync across devices, etc.) that never get in the way of writing. ![mac]
+- [Texifier](https://www.texifier.com/) - Commercial LaTeX editor for macOS and iOS, with excellent features (document overview, synchronised PDF display, autocompletion, sync across devices, etc.) that never get in the way of writing. ![mac]
 
 ### General purpose text editors
 


### PR DESCRIPTION
Texpad was renamed to texifier. The documentation has been reflected to match the name change.

Proof: Go to https://texpad.com. It redirects to texifier.com with a note at the top mentioning the rename.