### PR TITLE
Add Vexlio to Online Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Online editors that allow you to edit documents collaboratively.
 - [WebLaTeX](https://github.com/sanjib-sen/weblatex) - Web-based vscode with Git Integration + Copilot + Grammar & Spell Checker + Live Collaboration Support based on GitHub Codespace and Dev container.
 - [Papeeria](https://papeeria.com) - Online editor with built-in git support.
 - [JaxEdit](https://zohooo.GitHub.io/jaxedit/) - Online LaTeX editor with Live Preview and nice presentation mode.
+- [Vexlio](https://vexlio.com/) - Online diagram editor with built-in LaTeX equation support including live preview and easy exports. 
 
 ## Bibliography tools
 


### PR DESCRIPTION
Add free diagramming app Vexlio to the Online Editors section, which supports LaTeX equations natively with live preview, high-quality exports, etc. There are paid add-ons but the base app, including LaTeX support, is completely free.

There is also the standalone [equation editor](https://vexlio.com/equation-editor) at https://vexlio.com/equation-editor (also free) which is likely useful on its own, but the overall diagram editor is a strict superset of functionality, so it seemed a better fit for this list. Disclaimer, I am the developer of Vexlio.