### PR TITLE
Add abnt-citation to Bibliography tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Online editors that allow you to edit documents collaboratively.
 - [OneCite](https://github.com/HzaCode/OneCite) - Universal citation management and academic reference toolkit that converts messy references into perfectly formatted citations. Supports DOI, arXiv ID, titles, and more, with output in BibTeX, APA, and MLA formats. ![mac] ![windows] ![linux] ![foss]
 - [CrossRef Local](https://github.com/ywatanabe1989/crossref-local) - Local CrossRef database (167M papers) with full-text search, impact factor data, Python API for bibliography enrichment, and an MCP server (15 tools). ![foss]
 - [OpenAlex Local](https://github.com/ywatanabe1989/openalex-local) - Local OpenAlex database (284M scholarly works) with abstracts and semantic search for literature discovery, and an MCP server. ![foss]
+- [abnt-citation](https://github.com/danielnichiata96/abnt-citation) - TypeScript library for formatting citations and parsing author names per Brazilian ABNT standards (NBR 6023:2025, NBR 10520:2023). Zero dependencies. ![foss]
 
 ## Build Tools
 


### PR DESCRIPTION
## What is abnt-citation?

[abnt-citation](https://github.com/danielnichiata96/abnt-citation) is a TypeScript library for formatting academic citations and parsing author names according to Brazilian ABNT standards (NBR 6023:2025 and NBR 10520:2023). It is the only programmatic library specifically designed for ABNT citation formatting.

## Why it belongs here

- **ABNT standards** are required by virtually all Brazilian universities and many institutions across Latin America and Portuguese-speaking countries — this is the only open-source library that implements them programmatically
- **Zero dependencies** — lightweight and easy to integrate
- **MIT licensed**, actively maintained, with full test coverage
- **Used in production** at [CiteMe](https://citeme.app), serving thousands of students

**Disclosure: I am the maintainer of this package.** Self-promotion is declared per the contribution guidelines.