### PR TITLE
Add TeX64 to LaTeX-focused editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Some of the most awesome editor for LaTeX do just that: edit LaTeX.
 - [TeXWorks](https://www.tug.org/texworks/) - No-nonsense editor for LaTeX code, modeled after TeXShop, but this one is cross-platform. ![foss]
 - [BakomaTex](https://www.bakoma-tex.com) - Commercial LaTeX editor that allows to edit your document both using its source code and WYSIWYG.
 - [Texifier](https://www.texifier.com/) - Commercial LaTeX editor for macOS and iOS, with excellent features (document overview, synchronised PDF display, autocompletion, sync across devices, etc.) that never get in the way of writing. ![mac]
+- [TeX64](https://tex64.com) – Native macOS LaTeX editor with AI-powered error fixing, equation OCR, live PDF preview, and structured math editing. ![mac]
 
 ### General purpose text editors
 


### PR DESCRIPTION
Adding [TeX64](https://tex64.com) to the LaTeX-focused editors section.

TeX64 is a native macOS LaTeX editor featuring AI-powered error fixing (reads compilation logs and suggests one-click fixes), equation OCR (convert photos of handwritten/printed math to LaTeX), live PDF preview with SyncTeX, and structured math editing. It compiles locally via MacTeX/TeX Live with no cloud or account required.

Currently in public beta.