### PR TITLE
Add Androma TeX Editor to Online editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Online editors that allow you to edit documents collaboratively.
 - [OpenAI Prism](https://prism.openai.com) - Online editor with realtime collaboration features.
 - [Modern LaTeX Editor](https://github.com/InMDev/Modern-LaTeX-Editor) - Online editor, no-signup hybrid code editor + visual editor that mixes Notion/Google docs/Microsoft Word-like editing with raw LaTeX code blocks.
 - [Octree](https://www.useoctree.com) - Online editor with AI writing assistance.
+- [Androma TeX Editor](https://androma.org) - Collaborative LaTeX editor integrated into a mathematics wiki, with issue tracking, pull requests, and WASM-based compilation.
 - [Overleaf](https://www.overleaf.com) - Online editor, also with a WYSIWYM editor and git support.
   - [olcli](https://github.com/aloth/olcli) - Command-line interface for Overleaf to sync, manage, and compile projects from the terminal. ![foss]
 - [SciTeX Cloud](https://github.com/ywatanabe1989/scitex-cloud) - Self-hostable online editor with AI assistant integration, figure/table/citation management, real-time collaboration, and an MCP server (29 tools). ![foss]


### PR DESCRIPTION
Adds [Androma TeX Editor](https://androma.org) to the Online editors section.

Androma includes a collaborative LaTeX editor with:
- WASM-based in-browser compilation (no server round-trip)
- Issue tracking and pull request workflow (like GitHub for papers)
- Integrated into a mathematics wiki with theorem database and proofs
- Real-time collaboration