### PR TITLE
Add latex2arxiv to Quality Check Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Compiling LaTeX documents can be tedious, build tools help you to manage the com
 - [ChkTeX](https://www.nongnu.org/chktex/) - Linter / code checker for LaTeX documents. ![foss]
 - [blacktex](https://github.com/nschloe/blacktex) - Command-line tool that replaces commonly occurring LaTeX anti-patterns and cleans up your files. ![windows] ![linux] ![mac] ![foss]
 - [TeXtidote](https://github.com/sylvainhalle/textidote) - A cross-platform (Java) spelling, grammar and style checker for LaTeX documents. ![windows] ![linux] ![mac] ![foss]
+- [latex2arxiv](https://github.com/YuZh98/latex2arxiv) - CLI tool that prepares a LaTeX project for arXiv submission: prunes unreachable files, strips draft markup, validates the bibliography, and catches desk-rejection errors before upload. Also available as a GitHub Action and MCP server for AI agents. ![windows] ![linux] ![mac] ![foss]
 
 ### Tools centered around equations
 


### PR DESCRIPTION
## What

Adds [latex2arxiv](https://github.com/YuZh98/latex2arxiv) to the **Quality Check Tools** section.

## Why it fits

latex2arxiv is a CLI tool that validates and prepares a LaTeX project for arXiv submission before upload:

- Detects packages/commands that cause desk rejection (e.g. `\usepackage{minted}`, `\includeonly`)
- Prunes unreachable files from the project tree
- Strips draft markup and TODO comments
- Validates bibliography entries
- Outputs a clean, submission-ready zip

Available via **PyPI**, **Homebrew**, **GitHub Actions**, **pre-commit hook**, and an **MCP server** for AI agent workflows.

This fills a gap: the current Quality Check Tools focus on style/grammar (ChkTeX, blacktex, TeXtidote) but none specifically target arXiv submission compliance.