### PR TITLE
Adds OpenTikZ under Packages → Graphics → TikZ.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Typically, it is easier to get to work with `pdflatex` than PSTricks is.
 - [matlab2tikz](https://github.com/matlab2tikz/matlab2tikz) - Convert your MATLAB plots to PGFPlots/TikZ. ![windows] ![linux] ![mac] ![foss]
 - [tikzplotlib](https://github.com/nschloe/tikzplotlib) - Convert your matplotlib plots to PGFPlots/TikZ. ![windows] ![linux] ![mac] ![foss]
 - [TikZBlog](https://latexdraw.com) - Step-by-Step Tutorials about How to Draw Illustrations in LaTeX.
+- [OpenTikZ](https://github.com/opentikz/opentikz) - Community library of copyable TikZ icons and editable, parametric templates for academic conceptual diagrams (system/architecture, pipelines, flowcharts); CC0 content, with a Claude Code skill to edit figures on request. ![foss]
 
 ### Source Code
 


### PR DESCRIPTION
OpenTikZ is a community library of TikZ resources for academic conceptual diagrams, offering:
- copyable single-concept icons
- editable, parametric architecture/pipeline/flow templates 
- AI Agent skill to cope with modification and generation

All graphic content is CC0-licensed for frictionless reuse in papers. 

Repo: https://github.com/opentikz/opentikz

Site: https://opentikz.org