### PR TITLE
Add Language Servers and Formatters sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Online editors that allow you to edit documents collaboratively.
 Language servers bring IDE features (completion, diagnostics, navigation, and more) to any editor that speaks the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/), such as Neovim, VS Code, Emacs, and Helix.
 
 - [TexLab](https://github.com/latex-lsp/texlab) - Language server for LaTeX and BibTeX with completion, definitions, references, rename, formatting, and forward search. ![foss]
+- [Badness](https://github.com/jolars/badness) - Language server, formatter, and linter for LaTeX built on a lossless, error-tolerant syntax tree in the style of rust-analyzer. ![foss]
 
 ## Bibliography tools
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     - [LaTeX-focused](#latex-focused)
     - [General purpose text editors](#general-purpose-text-editors)
     - [Online editors](#online-editors)
+  - [Language Servers](#language-servers)
   - [Bibliography tools](#bibliography-tools)
   - [Build Tools](#build-tools)
     - [GitHub Actions](#github-actions)
@@ -152,6 +153,12 @@ Online editors that allow you to edit documents collaboratively.
 - [JaxEdit](https://zohooo.GitHub.io/jaxedit/) - Online LaTeX editor with Live Preview and nice presentation mode.
 - [Vexlio](https://vexlio.com/) - Online diagram editor with built-in LaTeX equation support including live preview and easy exports. 
 - [TeXbrain](https://tex.swimmingbrain.dev) - Free, open-source browser-based LaTeX editor with in-browser compilation, live PDF preview and Git integration. No account or install required. ![foss]
+
+## Language Servers
+
+Language servers bring IDE features (completion, diagnostics, navigation, and more) to any editor that speaks the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/), such as Neovim, VS Code, Emacs, and Helix.
+
+- [TexLab](https://github.com/latex-lsp/texlab) - Language server for LaTeX and BibTeX with completion, definitions, references, rename, formatting, and forward search. ![foss]
 
 ## Bibliography tools
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Formatters keep the layout of your LaTeX source consistent, so that you can focu
 
 - [latexindent](https://ctan.org/pkg/latexindent) - Perl script that indents and reformats LaTeX documents, highly configurable through YAML settings and shipped with the major TeX distributions. ![foss]
 - [tex-fmt](https://github.com/WGUNDERWOOD/tex-fmt) - Extremely fast LaTeX formatter written in Rust, with sensible defaults and minimal configuration. ![foss]
+- [Badness](https://github.com/jolars/badness) - Deterministic, rule-based, and idempotent LaTeX formatter written in Rust (also a linter and language server). ![foss]
 
 ### Quality Check Tools
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   - [Build Tools](#build-tools)
     - [GitHub Actions](#github-actions)
   - [Misc. Tools](#misc-tools)
+    - [Formatters](#formatters)
     - [Quality Check Tools](#quality-check-tools)
     - [Tools centered around equations](#tools-centered-around-equations)
   - [LaTeX-compatible GUI tools](#latex-compatible-gui-tools)
@@ -193,6 +194,12 @@ Compiling LaTeX documents can be tedious, build tools help you to manage the com
 - [CaTeX](https://github.com/Alexis-benoist/CaTeX) - Concatenates LaTeX documents with attention for properly merging the preamble.
 - [Pandoc](https://pandoc.org) - This program converts almost any document format (LaTeX, DOC, markdown, etc.) to almost any other format. A great tool to aid workflows where multiple formats are used. ![foss]
 - [SciTeX Writer](https://github.com/ywatanabe1989/scitex-writer) - Manuscript compilation system with templates for manuscripts, revisions, and supplementary materials, plus figure, table, and citation handling, and an MCP server (38 tools). ![foss]
+
+### Formatters
+
+Formatters keep the layout of your LaTeX source consistent, so that you can focus on the content.
+
+- [latexindent](https://ctan.org/pkg/latexindent) - Perl script that indents and reformats LaTeX documents, highly configurable through YAML settings and shipped with the major TeX distributions. ![foss]
 
 ### Quality Check Tools
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Compiling LaTeX documents can be tedious, build tools help you to manage the com
 Formatters keep the layout of your LaTeX source consistent, so that you can focus on the content.
 
 - [latexindent](https://ctan.org/pkg/latexindent) - Perl script that indents and reformats LaTeX documents, highly configurable through YAML settings and shipped with the major TeX distributions. ![foss]
+- [tex-fmt](https://github.com/WGUNDERWOOD/tex-fmt) - Extremely fast LaTeX formatter written in Rust, with sensible defaults and minimal configuration. ![foss]
 
 ### Quality Check Tools
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Online editors that allow you to edit documents collaboratively.
 Language servers bring IDE features (completion, diagnostics, navigation, and more) to any editor that speaks the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/), such as Neovim, VS Code, Emacs, and Helix.
 
 - [TexLab](https://github.com/latex-lsp/texlab) - Language server for LaTeX and BibTeX with completion, definitions, references, rename, formatting, and forward search. ![foss]
-- [Badness](https://github.com/jolars/badness) - Language server, formatter, and linter for LaTeX built on a lossless, error-tolerant syntax tree in the style of rust-analyzer. ![foss]
+- [Badness][badness] - Language server, formatter, and linter for LaTeX built on a lossless, error-tolerant syntax tree in the style of rust-analyzer. ![foss]
 
 ## Bibliography tools
 
@@ -201,14 +201,14 @@ Formatters keep the layout of your LaTeX source consistent, so that you can focu
 
 - [latexindent](https://ctan.org/pkg/latexindent) - Perl script that indents and reformats LaTeX documents, highly configurable through YAML settings and shipped with the major TeX distributions. ![foss]
 - [tex-fmt](https://github.com/WGUNDERWOOD/tex-fmt) - Extremely fast LaTeX formatter written in Rust, with sensible defaults and minimal configuration. ![foss]
-- [Badness](https://github.com/jolars/badness) - Deterministic, rule-based, and idempotent LaTeX formatter written in Rust (also a linter and language server). ![foss]
+- [Badness][badness] - Deterministic, rule-based, and idempotent LaTeX formatter written in Rust (also a linter and language server). ![foss]
 
 ### Quality Check Tools
 
 - [ChkTeX](https://www.nongnu.org/chktex/) - Linter / code checker for LaTeX documents. ![foss]
 - [blacktex](https://github.com/nschloe/blacktex) - Command-line tool that replaces commonly occurring LaTeX anti-patterns and cleans up your files. ![windows] ![linux] ![mac] ![foss]
 - [TeXtidote](https://github.com/sylvainhalle/textidote) - A cross-platform (Java) spelling, grammar and style checker for LaTeX documents. ![windows] ![linux] ![mac] ![foss]
-- [Badness](https://github.com/jolars/badness) - Error-tolerant LaTeX linter with rich diagnostics and source snippets (also a formatter and language server). ![foss]
+- [Badness][badness] - Error-tolerant LaTeX linter with rich diagnostics and source snippets (also a formatter and language server). ![foss]
 
 ### Tools centered around equations
 
@@ -371,3 +371,4 @@ All trademarks are property of their respective owners.
 [windows]: https://cdn.jsdelivr.net/gh/egeerardyn/awesome-LaTeX@700138fe725574e1741f148df6d1f77a8aa07eee/fig/windows.svg
 [foss]: https://cdn.jsdelivr.net/gh/egeerardyn/awesome-LaTeX@700138fe725574e1741f148df6d1f77a8aa07eee/fig/foss.svg
 [awesome]: https://cdn.jsdelivr.net/gh/sindresorhus/awesome@d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
+[badness]: https://github.com/jolars/badness

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Formatters keep the layout of your LaTeX source consistent, so that you can focu
 - [ChkTeX](https://www.nongnu.org/chktex/) - Linter / code checker for LaTeX documents. ![foss]
 - [blacktex](https://github.com/nschloe/blacktex) - Command-line tool that replaces commonly occurring LaTeX anti-patterns and cleans up your files. ![windows] ![linux] ![mac] ![foss]
 - [TeXtidote](https://github.com/sylvainhalle/textidote) - A cross-platform (Java) spelling, grammar and style checker for LaTeX documents. ![windows] ![linux] ![mac] ![foss]
+- [Badness](https://github.com/jolars/badness) - Error-tolerant LaTeX linter with rich diagnostics and source snippets (also a formatter and language server). ![foss]
 
 ### Tools centered around equations
 


### PR DESCRIPTION
This PR adds two new categories, following the guideline that new categories and improvements to the categorization are welcome. One item per commit, and the table of contents is updated.

## Language Servers

- **TexLab** - the de facto standard LaTeX language server, bringing completion, navigation, and forward search to any LSP-capable editor.
- **Badness** - a language server, formatter, and linter built on a lossless, error-tolerant syntax tree in the style of rust-analyzer.

## Formatters (under Misc. Tools)

- **latexindent** - the long-standing, highly configurable formatter shipped with the major TeX distributions.
- **tex-fmt** - an extremely fast Rust formatter with sensible defaults.
- **Badness** - a deterministic, idempotent, rule-based formatter.

## Quality Check Tools (existing section)

- **Badness** - its `lint` command reports diagnostics with source snippets, fitting alongside ChkTeX.

**Note on duplication**: Badness is one tool that genuinely spans all three categories (language server, formatter, and linter). I have listed it in each so readers browsing a single category find it, but I am happy to consolidate it into just one section if you prefer.

**Disclosure**: I am the author of Badness. The other three tools I use and can personally recommend; texlab, tex-fmt, and latexindent are widely used staples of editor-based LaTeX workflows.