### PR TITLE
Add Oleafly to LaTeX-focused editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Some of the most awesome editor for LaTeX do just that: edit LaTeX.
 - [TeXWorks](https://www.tug.org/texworks/) - No-nonsense editor for LaTeX code, modeled after TeXShop, but this one is cross-platform. ![foss]
 - [BakomaTex](https://www.bakoma-tex.com) - Commercial LaTeX editor that allows to edit your document both using its source code and WYSIWYG.
 - [Texifier](https://www.texifier.com/) - Commercial LaTeX editor for macOS and iOS, with excellent features (document overview, synchronised PDF display, autocompletion, sync across devices, etc.) that never get in the way of writing. ![mac]
+- [Oleafly](https://github.com/Oleafly/Oleafly) - Free, open-source desktop editor for LaTeX, Typst, and Markdown with live PDF preview, SyncTeX, bundled engines, and Git-native projects. ![foss]
 
 ### General purpose text editors
 


### PR DESCRIPTION
## Summary

Adds [Oleafly](https://github.com/Oleafly/Oleafly) under **Editors → LaTeX-focused**.

Oleafly is a free, open-source (AGPL-3.0) desktop app for macOS, Windows, and Linux. It is local-first, works without an account, and targets scientific writing with:

- LaTeX, Typst, and Markdown projects
- Live PDF preview and bidirectional SyncTeX
- Bundled Tectonic/Typst engines (no full TeX install required for the default workflow)
- Git-native project history

**Disclosure:** I am the maintainer of Oleafly.

## Checklist

- [x] One item, added at the bottom of the relevant category
- [x] Format matches existing entries (`[Name](link) - description.`)
- [x] Brief reason why it belongs on the list
- [x] Self-promotion disclosed

## Entry

```markdown
- [Oleafly](https://github.com/Oleafly/Oleafly) - Free, open-source desktop editor for LaTeX, Typst, and Markdown with live PDF preview, SyncTeX, bundled engines, and Git-native projects. ![foss]
```