### PR TITLE
Add LetX to Online editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Online editors that allow you to edit documents collaboratively.
 - [JaxEdit](https://zohooo.GitHub.io/jaxedit/) - Online LaTeX editor with Live Preview and nice presentation mode.
 - [Vexlio](https://vexlio.com/) - Online diagram editor with built-in LaTeX equation support including live preview and easy exports. 
 - [TeXbrain](https://tex.swimmingbrain.dev) - Free, open-source browser-based LaTeX editor with in-browser compilation, live PDF preview and Git integration. No account or install required. ![foss]
+- [LetX](https://letx.app) - Online editor with real-time multi-author collaboration (CRDT), bidirectional SyncTeX, and 1000+ journal/thesis templates.
 
 ## Bibliography tools
 


### PR DESCRIPTION
**Disclosure: I built LetX.** Adding it per the contributing guideline that self-promotion is fine when involvement is clearly stated.

[LetX](https://letx.app) is a browser-based collaborative LaTeX editor. What makes it worth listing alongside the existing entries:

- **Real-time multi-author editing via CRDTs** — several people edit the same file simultaneously with conflict-free merging, and every project gets unlimited collaborators on the free plan (Overleaf's free tier allows one).
- **Bidirectional SyncTeX** — click in the source to jump to that spot in the PDF and vice versa.
- **1000+ journal and thesis templates** across 20 categories, including IEEE/Springer/Elsevier submission formats, university thesis layouts, and lab documentation.
- Compiles server-side on a full TeX Live installation (pdfLaTeX, XeLaTeX, LuaLaTeX), so packages behave as they do locally.
- User documents are not used to train AI models.

It has been in production since January 2026 and is used at 100+ universities and research labs.

Followed the contributing guidelines: one item in one commit, appended to the bottom of the relevant category, formatted as `[Name](link) - description.` with a trailing period. No table-of-contents change was needed since no new category was added.