### PR TITLE
Add overleaf-comments-export under Overleaf

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Online editors that allow you to edit documents collaboratively.
 - [Androma TeX Editor](https://androma.org) - Collaborative LaTeX editor integrated into a mathematics wiki, with issue tracking, pull requests, and WASM-based compilation.
 - [Overleaf](https://www.overleaf.com) - Online editor, also with a WYSIWYM editor and git support. Also available as [Overleaf Community Edition](https://github.com/overleaf/overleaf) (self-hosted, AGPL licensed). ![foss]
   - [olcli](https://github.com/aloth/olcli) - Command-line interface for Overleaf to sync, manage, and compile projects from the terminal. ![foss]
+  - [overleaf-comments-export](https://github.com/Mangluu/overleaf-comments-export) - Exports comment threads, replies and tracked changes to Markdown and JSON, and annotates the compiled PDF with highlights on the commented text. ![foss]
 - [SciTeX Cloud](https://github.com/ywatanabe1989/scitex-cloud) - Self-hostable online editor with AI assistant integration, figure/table/citation management, real-time collaboration, and an MCP server (29 tools). ![foss]
 - [WebLaTeX](https://github.com/sanjib-sen/weblatex) - Web-based vscode with Git Integration + Copilot + Grammar & Spell Checker + Live Collaboration Support based on GitHub Codespace and Dev container.
 - [Papeeria](https://papeeria.com) - Online editor with built-in git support.


### PR DESCRIPTION
**Disclosure: I wrote overleaf-comments-export.**

Adds [overleaf-comments-export](https://github.com/Mangluu/overleaf-comments-export) as a sub-entry of Overleaf, next to olcli.

Overleaf does not include review comments in its source download or in its Git sync, so feedback from co-authors and supervisors can only be worked through inside the editor, one comment at a time. This exports every thread with its replies and any tracked changes, mapped back to the file, section and line they were attached to, as Markdown and JSON.

It also annotates the compiled PDF, highlighting the words each comment was written about and colouring them by who wrote it. It does that to the PDF Overleaf has already built rather than by compiling anything, so it needs no LaTeX installation.

MIT licensed, and it runs locally against the user's own session.

I put it under Overleaf rather than in Misc. Tools because it only works with Overleaf, which is the same reason olcli sits there.

One note on the lint job. The new line reports `List item description must end with proper punctuation`, the same error already reported for the Overleaf and olcli entries directly above it and for the other 70 entries carrying a `![foss]` badge, since the badge follows the full stop. The count goes from 113 to 114. I kept the badge so the entry matches its neighbours, but I am happy to drop it if you would rather not add another instance.
