### PR TITLE
Add Texpile to LaTeX-focused editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Some of the most awesome editor for LaTeX do just that: edit LaTeX.
 - [Texifier](https://www.texifier.com/) - Commercial LaTeX editor for macOS and iOS, with excellent features (document overview, synchronised PDF display, autocompletion, sync across devices, etc.) that never get in the way of writing. ![mac]
 - [TeX64](https://tex64.com) – Native macOS LaTeX editor with AI-powered error fixing, equation OCR, live PDF preview, and structured math editing. ![mac]
 - [Oleafly](https://github.com/Oleafly/Oleafly) - Free, open-source desktop editor for LaTeX, Typst, and Markdown with live PDF preview, SyncTeX, bundled engines, and Git-native projects. ![foss]
+- [Texpile](https://texpile.com) - Free and open-source desktop editor that edits LaTeX visually (like LyX) or by source with IntelliSense. Supports end-to-end encrypted real-time collaboration. ![foss]
 
 ### General purpose text editors
 


### PR DESCRIPTION
Disclosure: I'm the author of Texpile.

Free and open source (AGPL-3.0), Windows/macOS/Linux.

Currently visual editing in LaTeX is covered by tools that store the document in their own format. Texpile's visual editor stores directly as .tex and opens any .tex files. Besides visual editing, Texpile is a good source editor with modern UI/UX and IntelliSense.